### PR TITLE
chore: upgrade to Minecraft 1.21.7 and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
         mappings loom.layered() {
             officialMojangMappings()
-            parchment("org.parchmentmc.data:parchment-1.21.5:2025.06.15@zip")
+            parchment("org.parchmentmc.data:parchment-1.21.7:2025.07.18@zip")
         }
 
         // incremental storage

--- a/common/src/main/java/io/github/skydynamic/quickbakcupmulti/client/screen/RestoreScreen.java
+++ b/common/src/main/java/io/github/skydynamic/quickbakcupmulti/client/screen/RestoreScreen.java
@@ -33,18 +33,18 @@ public class RestoreScreen extends Screen {
         int centerY = this.height / 2;
         guiGraphics.drawCenteredString(font, Component.nullToEmpty(this.state), centerX, centerY - 20, 0xFFFFFF);
         drawProgressBar(
-            guiGraphics,
-            centerX - 70,
-            centerY - 5,
-            centerX + 70,
-            centerY + 5
+                guiGraphics,
+                centerX - 70,
+                centerY - 5,
+                centerX + 70,
+                centerY + 5
         );
         guiGraphics.drawCenteredString(
-            font,
-            Component.nullToEmpty(Translate.tr("quickbackupmulti.screen.restore_screen.progress", this.getPercentString())),
-            centerX,
-            centerY + 10,
-            0xFFFFFF
+                font,
+                Component.nullToEmpty(Translate.tr("quickbackupmulti.screen.restore_screen.progress", this.getPercentString())),
+                centerX,
+                centerY + 10,
+                0xFFFFFF
         );
     }
 
@@ -90,7 +90,7 @@ public class RestoreScreen extends Screen {
     @Override
     public void renderBackground(GuiGraphics guiGraphics, int i, int j, float f) {
         this.renderPanorama(guiGraphics, f);
-        this.renderBlurredBackground();
+        this.renderBlurredBackground(guiGraphics);
         this.renderMenuBackground(guiGraphics);
     }
 }

--- a/common/src/main/java/io/github/skydynamic/quickbakcupmulti/command/RestoreCommand.java
+++ b/common/src/main/java/io/github/skydynamic/quickbakcupmulti/command/RestoreCommand.java
@@ -31,17 +31,25 @@ import static io.github.skydynamic.quickbakcupmulti.translate.Translate.tr;
 public class RestoreCommand {
     public static final LiteralArgumentBuilder<CommandSourceStack> restoreCmd = Commands.literal("restore")
         .requires(it -> PermissionManager.hasPermission(it, 4, PermissionType.ADMIN))
-        .then(Commands.argument("name", StringArgumentType.string())
+        .then(Commands.argument("target", StringArgumentType.string())
             .suggests(((context, builder) -> {
-                for (StorageInfo info : BackupManager.getBackupsList()) {
-                    if (info.getName().contains(builder.getRemaining())) {
-                        builder.suggest(info.getName());
+                List<StorageInfo> backups = BackupManager.getSortedBackups();
+                String remaining = builder.getRemaining();
+                int index = 1;
+                for (StorageInfo info : backups) {
+                    String name = info.getName();
+                    if (name.contains(remaining)) {
+                        builder.suggest(name);
+                    }
+                    String idx = String.valueOf(index++);
+                    if (idx.startsWith(remaining)) {
+                        builder.suggest(idx);
                     }
                 }
                 return builder.buildFuture();
             }))
             .executes(it ->
-                restoreBackup(it.getSource(), StringArgumentType.getString(it, "name"))
+                restoreBackup(it.getSource(), StringArgumentType.getString(it, "target"))
             )
         );
 
@@ -63,8 +71,9 @@ public class RestoreCommand {
     @Getter
     private static final ConcurrentHashMap<String, ConcurrentHashMap<String, Object>> restoreDataMap = new ConcurrentHashMap<>();
 
-    private static int restoreBackup(CommandSourceStack commandSource, String name) {
-        if (!QuickbakcupmultiReforged.getDatabase().storageExists(name)) {
+    private static int restoreBackup(CommandSourceStack commandSource, String target) {
+        String name = resolveBackupName(target);
+        if (name == null || !QuickbakcupmultiReforged.getDatabase().storageExists(name)) {
             commandSource.sendSystemMessage(Component.nullToEmpty(tr("quickbackupmulti.restore.fail")));
             return 0;
         }
@@ -140,5 +149,23 @@ public class RestoreCommand {
             commandSource.sendSystemMessage(Component.nullToEmpty(tr("quickbackupmulti.confirm_restore.nothing_to_confirm")));
         }
         return 1;
+    }
+
+    private static String resolveBackupName(String target) {
+        String trimmed = target.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        if (trimmed.chars().allMatch(Character::isDigit)) {
+            try {
+                int index = Integer.parseInt(trimmed);
+                StorageInfo info = BackupManager.getBackupByIndex(index);
+                if (info != null) {
+                    return info.getName();
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return trimmed;
     }
 }

--- a/common/src/main/java/io/github/skydynamic/quickbakcupmulti/restore/ClientRestoreDelegate.java
+++ b/common/src/main/java/io/github/skydynamic/quickbakcupmulti/restore/ClientRestoreDelegate.java
@@ -26,8 +26,10 @@ public class ClientRestoreDelegate {
     public void run() {
         long startTime = System.currentTimeMillis();
         minecraftClient.executeBlocking(() -> {
-            minecraftClient.level.disconnect();
-            minecraftClient.disconnect(screen);
+            if (minecraftClient.level != null) {
+                minecraftClient.level.disconnect(Component.translatable("multiplayer.status.quitting"));
+            }
+            minecraftClient.disconnect(screen, false);
         });
 
         restoreFuture = CompletableFuture.runAsync(() -> {
@@ -65,7 +67,7 @@ public class ClientRestoreDelegate {
             });
             if (QuickbakcupmultiReforged.getModConfig().isClientAutoReJoinWorld()) {
                 minecraftClient.execute(() -> minecraftClient.createWorldOpenFlows().openWorld(levelId,
-                    () -> minecraftClient.setScreen(null)));
+                        () -> minecraftClient.setScreen(null)));
             } else {
                 minecraftClient.execute(() -> minecraftClient.setScreen(null));
             }

--- a/common/src/main/java/io/github/skydynamic/quickbakcupmulti/utils/BackupManager.java
+++ b/common/src/main/java/io/github/skydynamic/quickbakcupmulti/utils/BackupManager.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -52,6 +53,30 @@ public class BackupManager {
             backupList = DatabaseCache.getStorageInfoCaches();
         }
         return backupList;
+    }
+
+    public static List<StorageInfo> getSortedBackups() {
+        return getBackupsList().stream()
+            .sorted(Comparator.comparingLong(StorageInfo::getTimestamp))
+            .toList();
+    }
+
+    public static StorageInfo getBackupByIndex(int index) {
+        List<StorageInfo> backups = getSortedBackups();
+        if (index < 1 || index > backups.size()) {
+            return null;
+        }
+        return backups.get(index - 1);
+    }
+
+    public static int getBackupIndex(String name) {
+        List<StorageInfo> backups = getSortedBackups();
+        for (int i = 0; i < backups.size(); i++) {
+            if (backups.get(i).getName().equals(name)) {
+                return i + 1;
+            }
+        }
+        return -1;
     }
 
     public static void makeBackup(CommandSourceStack commandSource, String name, String desc) {

--- a/common/src/main/java/io/github/skydynamic/quickbakcupmulti/utils/ListBackupsUtils.java
+++ b/common/src/main/java/io/github/skydynamic/quickbakcupmulti/utils/ListBackupsUtils.java
@@ -1,7 +1,6 @@
 package io.github.skydynamic.quickbakcupmulti.utils;
 
 import io.github.skydynamic.increment.storage.lib.database.StorageInfo;
-import io.github.skydynamic.quickbakcupmulti.DatabaseCache;
 import io.github.skydynamic.quickbakcupmulti.QuickbakcupmultiReforged;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.ClickEvent;
@@ -14,9 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.text.SimpleDateFormat;
-import java.util.Comparator;
 import java.util.List;
 
 import static io.github.skydynamic.quickbakcupmulti.translate.Translate.tr;
@@ -67,14 +64,16 @@ public class ListBackupsUtils {
         return getPageNavigationText("[->]", page, totalPage, 1);
     }
 
-    private static MutableComponent getSlotText(StorageInfo info, int page, int num) throws IOException {
+    private static MutableComponent getSlotText(StorageInfo info, int page, int num, int globalIndex) throws IOException {
         String name = info.getName();
         MutableComponent backText = Component.literal("§2[▷] ");
         MutableComponent deleteText = Component.literal("§c[×] ");
         MutableComponent nameText = Component.literal("§6" + truncateString(name, 8) + "§r ");
+        MutableComponent indexText = Component.literal("#" + globalIndex + " ")
+            .withStyle(style -> style.withColor(ChatFormatting.GRAY));
         MutableComponent resultText = Component.literal("");
 
-        backText.withStyle(style -> style.withClickEvent(new ClickEvent.SuggestCommand("/qb restore \"%s\"".formatted(name))))
+        backText.withStyle(style -> style.withClickEvent(new ClickEvent.SuggestCommand("/qb restore " + globalIndex)))
             .withStyle(style -> style.withHoverEvent(
                 new HoverEvent.ShowText(Component.nullToEmpty(tr("quickbackupmulti.list_backup.slot.restore", name)))));
 
@@ -89,6 +88,7 @@ public class ListBackupsUtils {
         String desc = info.getDesc();
         if (desc.isEmpty()) desc = "Empty";
         resultText.append("\n" + tr("quickbackupmulti.list_backup.slot.header", num + (5 * (page - 1))) + " ")
+            .append(indexText)
             .append(nameText)
             .append(backText)
             .append(deleteText)
@@ -98,10 +98,7 @@ public class ListBackupsUtils {
 
     public static MutableComponent list(int page) {
         long totalBackupSizeB = 0;
-        List<StorageInfo> backupList = BackupManager.getBackupsList();
-        List<StorageInfo> backupsInfoList = backupList.stream()
-            .sorted(Comparator.comparingLong(StorageInfo::getTimestamp))
-            .toList();
+        List<StorageInfo> backupsInfoList = BackupManager.getSortedBackups();
         if (backupsInfoList.isEmpty() || getPageCount(backupsInfoList, page) == 0) {
             return Component.literal(tr("quickbackupmulti.list_empty"));
         }
@@ -123,8 +120,8 @@ public class ListBackupsUtils {
         for (int j = 1; j <= getPageCount(backupsInfoList, page); j++) {
             try {
                 StorageInfo info = backupsInfoList.get(((j - 1) + BACKUPS_PER_PAGE * (page - 1)));
-                String name = info.getName();
-                resultText.append(getSlotText(info, page, j));
+                int globalIndex = (page - 1) * BACKUPS_PER_PAGE + j;
+                resultText.append(getSlotText(info, page, j, globalIndex));
             } catch (IOException e) {
                 logger.error("Error while listing backups", e);
                 return Component.literal("Error while listing backups").withStyle(ChatFormatting.RED);
@@ -143,7 +140,11 @@ public class ListBackupsUtils {
             try {
                 String name = searchResultList.get(i - 1);
                 StorageInfo result = QuickbakcupmultiReforged.getDatabase().getStorageInfoWithName(name);
-                resultText.append(getSlotText(result, 1, i));
+                int globalIndex = BackupManager.getBackupIndex(name);
+                if (globalIndex <= 0) {
+                    globalIndex = i;
+                }
+                resultText.append(getSlotText(result, 1, i, globalIndex));
             } catch (IOException e) {
                 logger.error("Error while searching backups", e);
                 return Component.literal("Error while searching backups").withStyle(ChatFormatting.RED);

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -24,6 +24,7 @@ configurations {
 
 dependencies {
     modImplementation "net.fabricmc:fabric-loader:$rootProject.fabric_loader_version"
+    modImplementation "net.fabricmc:fabric-language-kotlin:1.13.0+kotlin.2.1.0"
 
     Set<String> apiModules = [
             "fabric-command-api-v2",

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,11 @@ mod_id = quickbakcupmulti_reforged
 archives_name = QuickBakcupMulti-Reforged
 enabled_platforms = fabric,neoforge
 # Minecraft properties
-minecraft_version = 1.21.5
+minecraft_version = 1.21.7
 minecraft_supported_versions = [1.21.5, )
 # Dependencies
-fabric_loader_version = 0.16.10
-fabric_api_version = 0.123.0+1.21.5
-neoforge_version = 21.5.65-beta
+fabric_loader_version = 0.16.13
+fabric_api_version = 0.129.0+1.21.7
+neoforge_version = 21.7.25-beta
 
 incremental_storage_lib_version=1.2.0+build.25080123.45


### PR DESCRIPTION
- Update minecraft version from 1.21.5 to 1.21.7
- Update parchment mappings to 1.21.7:2025.07.18
- Update fabric-loader to 0.16.13
- Update fabric-api to 0.129.0+1.21.7
- Update neoforge to 21.7.25-beta
- Fix renderBlurredBackground method signature in RestoreScreen
- Fix ClientRestoreDelegate level disconnect parameters
- Add null check for minecraftClient.level before disconnect
- Format code indentation